### PR TITLE
Incremental improvement to the example code

### DIFF
--- a/cloud-stream-replier/src/main/java/com/solace/samples/spring/scs/CloudStreamReplierApplication.java
+++ b/cloud-stream-replier/src/main/java/com/solace/samples/spring/scs/CloudStreamReplierApplication.java
@@ -9,11 +9,14 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.support.MessageBuilder;
 
-import com.solacesystems.jcsmp.Destination;
+
 
 @SpringBootApplication
 public class CloudStreamReplierApplication {
 
+	private static String REPLYTO_DESTINATION_KEY = "solace_replyTo";
+	private static String CORRELATION_ID_KEY = "solace_correlationId";
+	
 	public static void main(String[] args) {
 		SpringApplication.run(CloudStreamReplierApplication.class, args);
 	}
@@ -26,8 +29,8 @@ public class CloudStreamReplierApplication {
 			String uppercasedPayload = payload.toUpperCase();
 			
 			// Get the Topic to replyTo and correlation ID
-			Destination replyToTopic = (Destination) request.getHeaders().get("solace_replyTo");
-			String cid = (String) request.getHeaders().get("solace_correlationId");
+			String replyToTopic = request.getHeaders().get(REPLYTO_DESTINATION_KEY).toString();
+			String cid = request.getHeaders().get(CORRELATION_ID_KEY).toString();
 			
 			System.out.println("Processing request with cid of: " + cid);
 			System.out.println("ReplyTo Topic: " + replyToTopic.toString());
@@ -35,7 +38,7 @@ public class CloudStreamReplierApplication {
 			// Return Response Message w/ target destination set
 			return MessageBuilder.withPayload(uppercasedPayload)
 					.setHeader(BinderHeaders.TARGET_DESTINATION, replyToTopic.toString())
-					.setHeader("solace_correlationId", cid)
+					.setHeader(CORRELATION_ID_KEY, cid)
 					.build();
 		};
 	}

--- a/cloud-stream-requestor/src/main/java/com/solace/samples/spring/scs/CloudStreamRequestorApplication.java
+++ b/cloud-stream-requestor/src/main/java/com/solace/samples/spring/scs/CloudStreamRequestorApplication.java
@@ -20,6 +20,9 @@ import com.solacesystems.jcsmp.Topic;
 @SpringBootApplication
 public class CloudStreamRequestorApplication {
 
+	private static String REPLYTO_DESTINATION_KEY = "solace_replyTo";
+	private static String CORRELATION_ID_KEY = "solace_correlationId";
+	
 	private static String REPLYTO_TOPIC_PREFIX = "solace/scst/reply/example/";
 
 	private Map<String, Message<?>> outstandingRequests = new HashMap<String, Message<?>>();
@@ -38,7 +41,7 @@ public class CloudStreamRequestorApplication {
 	public Consumer<Message<String>> responseReceiver() {
 		return msg -> {
 			// Get Correlation ID
-			String correlationId = (String) msg.getHeaders().get("solace_correlationId");
+			String correlationId = (String) msg.getHeaders().get(CORRELATION_ID_KEY);
 			System.out.println("Received response for correlation id: " + correlationId);
 
 			// TODO Process Response here!
@@ -60,8 +63,8 @@ public class CloudStreamRequestorApplication {
 
 			// Create request message with proper headers
 			Message<?> requestMsg = MessageBuilder.withPayload(payload)
-					.setHeader("solace_replyTo", replyToTopic)
-					.setHeader("solace_correlationId", correlationId)
+					.setHeader(REPLYTO_DESTINATION_KEY, replyToTopic)
+					.setHeader(CORRELATION_ID_KEY, correlationId)
 					.build();
 
 			// Keep track of outstanding requests (if desired)


### PR DESCRIPTION
1) Define static String for the two message header keys that are used
2) Optimisation on the Replier application to use a simple String for the TARGET_DESTINATION, instead of a JCSMP.Destination.