### PR TITLE
Update CloudStreamReplierApplication.java

### DIFF
--- a/cloud-stream-replier/src/main/java/com/solace/samples/spring/scs/CloudStreamReplierApplication.java
+++ b/cloud-stream-replier/src/main/java/com/solace/samples/spring/scs/CloudStreamReplierApplication.java
@@ -29,17 +29,24 @@ public class CloudStreamReplierApplication {
 			String uppercasedPayload = payload.toUpperCase();
 			
 			// Get the Topic to replyTo and correlation ID
-			String replyToTopic = request.getHeaders().get(REPLYTO_DESTINATION_KEY).toString();
-			String cid = request.getHeaders().get(CORRELATION_ID_KEY).toString();
+			String replyToTopic = request.getHeaders().getOrDefault(REPLYTO_DESTINATION_KEY, "").toString();
+			String cid = request.getHeaders().getOrDefault(CORRELATION_ID_KEY, "").toString();
 			
 			System.out.println("Processing request with cid of: " + cid);
 			System.out.println("ReplyTo Topic: " + replyToTopic.toString());
 			
-			// Return Response Message w/ target destination set
-			return MessageBuilder.withPayload(uppercasedPayload)
-					.setHeader(BinderHeaders.TARGET_DESTINATION, replyToTopic.toString())
-					.setHeader(CORRELATION_ID_KEY, cid)
-					.build();
+			// Return Response Message w/ target destination set only if one provided, otherwise use binding config
+			if (replyToTopic.isEmpty()) {
+				return MessageBuilder.withPayload(uppercasedPayload)
+						.setHeader(CORRELATION_ID_KEY, cid)
+						.build();
+			}
+			else {
+				return MessageBuilder.withPayload(uppercasedPayload)						
+						.setHeader(CORRELATION_ID_KEY, cid)
+						.setHeader(BinderHeaders.TARGET_DESTINATION, replyToTopic.toString())
+						.build();
+			}
 		};
 	}
 }


### PR DESCRIPTION
1) Some hardening to better handle receipt of malformed messages. e.g. Those missing correlation IDs and reply-to topics.
2) A response for the service only goes to the reply-to destination if provided, otherwise default to binder config